### PR TITLE
Comparison between using radar SDK and not using radar SDK

### DIFF
--- a/SPMExample/ContentView.swift
+++ b/SPMExample/ContentView.swift
@@ -31,24 +31,24 @@ struct ContentView: View {
 }
 
 struct GetForegroundPermissionStateView: View {
-    
+    @ObservedObject var permissionsManager = PermissionsManager.shared
     var body: some View {
         VStack {
             Text("Get foreground location permissions, explain why you need them here.")
             Button("Request Foreground Permission") {
-                Radar.requestLocationPermissions(false)
+                permissionsManager.requestLocationPermissions(background: false)
             }
         }.navigationBarTitle("Get foreground", displayMode: .inline)
     }
 }
 
 struct GetBackgroundPermissionStateView: View {
-    
+    @ObservedObject var permissionsManager = PermissionsManager.shared
     var body: some View {
         VStack {
             Text("Get background location permissions, explain why you need them here")
             Button("Request Background Permission") {
-                Radar.requestLocationPermissions(true)
+                permissionsManager.requestLocationPermissions(background: true)
             }
         }.navigationBarTitle("Get background", displayMode: .inline)
     }

--- a/SPMExample/PermissionsManager.swift
+++ b/SPMExample/PermissionsManager.swift
@@ -9,16 +9,31 @@ import Foundation
 import CoreLocation
 import RadarSDK
 
-class PermissionsManager: NSObject, RadarDelegate, ObservableObject  {
+class PermissionsManager: NSObject, RadarDelegate, ObservableObject, CLLocationManagerDelegate {
     
     @Published var viewState:RadarLocationPermissionState
+
+    var locationManager: CLLocationManager
+
+    var danglingBackgroundPermissionsRequest = false
+    var inBackgroundLocationPopUp = false
+
+    // hold status of location permissions
+    var foregroundPopupAvailable = true
+    var backgroundPopupAvailable = true
+    var userRejectedBackgroundPermissions = false
+
     
     private override init() {
+        locationManager = CLLocationManager()
         viewState = RadarLocationPermissionState.NoPermissionsGranted
         super.init()
-        Radar.initialize(publishableKey: "000")
+        //Radar.initialize(publishableKey: "000")
         viewState = Radar.getLocationPermissionsStatus().locationPermissionState
-        Radar.setDelegate(self)
+        //Radar.setDelegate(self)
+        locationManager.delegate = self
+        NotificationCenter.default.addObserver(self, selector: #selector(applicationWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(applicationDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
     
     func didReceiveEvents(_ events: [RadarEvent], user: RadarUser?) {
@@ -42,8 +57,87 @@ class PermissionsManager: NSObject, RadarDelegate, ObservableObject  {
     }
     
     func didUpdateClientLocationPermissionsStatus(status: RadarLocationPermissionsStatus) {
-        viewState = status.locationPermissionState
+        // do nothing
     }
+
+    func requestLocationPermissions(background: Bool) {
+        if background && self.locationManager.authorizationStatus == .authorizedWhenInUse {
+            danglingBackgroundPermissionsRequest = true
+            backgroundPopupAvailable = false
+            updateStatus()
+            locationManager.requestAlwaysAuthorization()
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                if self.danglingBackgroundPermissionsRequest {
+                    print("pop-up did not show")
+                    self.userRejectedBackgroundPermissions = true
+                    self.updateStatus()
+                }
+                self.danglingBackgroundPermissionsRequest = false
+            }
+        }
+        
+        if !background {
+            foregroundPopupAvailable = false
+            updateStatus()
+            locationManager.requestWhenInUseAuthorization()
+        }
+    }
+
+    @objc func applicationDidBecomeActive() {
+        if inBackgroundLocationPopUp {
+            userRejectedBackgroundPermissions = true
+            updateStatus()
+        }
+        inBackgroundLocationPopUp = false
+    }
+    
+    @objc func applicationWillResignActive() {
+        if danglingBackgroundPermissionsRequest {
+            inBackgroundLocationPopUp = true
+            updateStatus()
+        }
+        danglingBackgroundPermissionsRequest = false
+    }
+
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        userRejectedBackgroundPermissions = userRejectedBackgroundPermissions || status == .denied
+        //let newStatus = RadarLocationPermissionsStatus(status: status, backgroundPopupAvailable: self.status.backgroundPopupAvailable, foregroundPopupAvailable: self.status.foregroundPopupAvailable, userRejectedBackgroundPermissions: self.status.userRejectedBackgroundPermissions || status == .denied)
+        updateStatus()
+    }
+
+    func updateStatus(){
+        let permissionStatus = self.locationManager.authorizationStatus
+        if permissionStatus == .notDetermined {
+            viewState = foregroundPopupAvailable ? RadarLocationPermissionState.NoPermissionsGranted : RadarLocationPermissionState.ForegroundPermissionsPending;
+        } else if permissionStatus == .denied {
+            viewState = RadarLocationPermissionState.ForegroundPermissionsRejected
+        } else if permissionStatus == .authorizedAlways {
+            viewState = RadarLocationPermissionState.BackgroundPermissionsGranted
+        } else if permissionStatus == .authorizedWhenInUse {
+            if userRejectedBackgroundPermissions {
+                viewState = RadarLocationPermissionState.BackgroundPermissionsRejected
+            } else {
+                viewState = backgroundPopupAvailable ? RadarLocationPermissionState.ForegroundPermissionsGranted : RadarLocationPermissionState.BackgroundPermissionsPending
+            }
+        } 
+        else if permissionStatus == .restricted {
+            viewState = RadarLocationPermissionState.PermissionsRestricted
+        }
+        else {
+            viewState = RadarLocationPermissionState.Unknown
+        }
+        print("Permissions status updated to: ")
+        print(viewState.rawValue)
+        print("Foreground popup available: ")
+        print(foregroundPopupAvailable)
+        print("Background popup available: ")
+        print(backgroundPopupAvailable)
+        print("User rejected background permissions: ")
+        print(userRejectedBackgroundPermissions)
+    }
+
+
 
     static let shared = PermissionsManager()
             


### PR DESCRIPTION
Side by side comparison of an robust permissions flow implementation powered by the Radar SDK vs one without.